### PR TITLE
added RJDemetra package

### DIFF
--- a/docker/rstudio/Dockerfile
+++ b/docker/rstudio/Dockerfile
@@ -137,6 +137,7 @@ RUN R CMD javareconf -e && \
     R -e "install.packages('sdcTable', dependencies=TRUE, repos='https://packagemanager.rstudio.com/cran/latest')" && \
     R -e "install.packages('DT', dependencies=TRUE, repos='https://packagemanager.rstudio.com/cran/latest')" && \
     R -e "install.packages('configr', dependencies=TRUE, repos='https://packagemanager.rstudio.com/cran/latest')" && \
+    R -e "install.packages('RJDemetra', dependencies=TRUE, repos='https://packagemanager.rstudio.com/cran/latest')" && \
     R -e "remotes::install_github('statisticsnorway/SSBpris')" && \
     R -e "remotes::install_github('statisticsnorway/Kostra')" && \
     R -e "remotes::install_github('statisticsnorway/SdcForetakPerson')" && \


### PR DESCRIPTION
Ref.: INC 51921

I forbindelse med at vi ikke kan bruke Proc IML i SAS lenger må vi legge sesongjusteringen i produksjonsløpet for en statistikk over til R.

Derfor lurer jeg på om dere har mulighet til å installere RJDemetra pakke på RStudio-server i prodsone?

Ser ikke ut til at jeg kan installere selv.

Mvh. Magnus Espeland