### PR TITLE
Endrer tilbake til 4.4.1

### DIFF
--- a/docker/rstudio/Dockerfile
+++ b/docker/rstudio/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update -y \
     # installing yad (yet another dialog)
     && apt-get -y install yad  \
     && apt-get install -y iputils-ping  \
-    # && apt-get install -y --no-install-recommends libaio1 libaio-dev \
+    && apt-get install -y --no-install-recommends libaio1 libaio-dev \
     && apt-get update -y \
     && apt-get upgrade -y \
     && apt autoremove -y \

--- a/docker/rstudio/Dockerfile
+++ b/docker/rstudio/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/geospatial:4.4.2
+FROM rocker/geospatial:4.4.1
 
 USER root
 


### PR DESCRIPTION
Versjon 4.4.2 bruker noble (ikke jammy). Fører til at det opprettes en ny mappe i library for renv (linux-ubuntu-noble)

4.4.1 bruker jammy – behold jammy frem til det er behov for å oppgradere?
