### PR TITLE
Added templater package

### DIFF
--- a/docker/rstudio/r-packages-src.R
+++ b/docker/rstudio/r-packages-src.R
@@ -31,6 +31,7 @@ remotes::install_github('statisticsnorway/ssb-pickmdl')
 remotes::install_github('statisticsnorway/ssb-fellesr', dependencies=TRUE, verbose=TRUE)
 remotes::install_github('statisticsnorway/ssb-easysdctable', dependencies=TRUE, verbose=TRUE)
 remotes::install_github('statisticsnorway/ReGenesees')
+remotes::install_github('statisticsnorway/ssb-templater', dependencies=TRUE)
 
 #install.packages('arrow', dependencies=FALSE, repos='https://packagemanager.rstudio.com/cran/latest')
 


### PR DESCRIPTION
Adding package to r-packages-src. I think this is cleaner than adding as an imports in the fellesr package.